### PR TITLE
Add a simple test method to the TestConfiguration class 

### DIFF
--- a/src/test/java/edu/berkeley/path/model_objects/TestConfiguration.java
+++ b/src/test/java/edu/berkeley/path/model_objects/TestConfiguration.java
@@ -9,6 +9,8 @@ import edu.berkeley.path.model_objects.scenario.DemandProfile;
 import edu.berkeley.path.model_objects.scenario.SplitRatioProfile;
 import edu.berkeley.path.model_objects.scenario.Splitratio;
 import edu.berkeley.path.model_objects.shared.CrudFlag;
+import org.junit.Test;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -112,5 +114,14 @@ public class TestConfiguration {
     r.setVehicleTypeId(veh_id);
     r.setContent(demands);
     return r;
+  }
+
+  @Test
+  public void doTest() {
+      try {
+          SplitRatioProfile sr = createSplitRatioProfile(20202, 0.0, 300.0, 10101, CrudFlag.CREATE);
+      } catch (Exception e) {
+          fail(e.getMessage());
+      }
   }
 }


### PR DESCRIPTION
so that JUnit with Java 7 doesn't barf because there's no test to invoke.

Changes to be committed:
modified:   src/test/java/edu/berkeley/path/model_objects/TestConfiguration.java